### PR TITLE
Fix Sovereign Tech links

### DIFF
--- a/content/blog/focusing-on-open-source/index.md
+++ b/content/blog/focusing-on-open-source/index.md
@@ -8,7 +8,7 @@ _build:
   list: "local"
 ---
 
-_tl;dr: I joined the [Sovereign Tech Agency](https://www.sovereign.tech//) as a Technologist to help make OSS more sustainable. It's a dream role that combines my passion for open source with my desire to tackle its biggest challenges._
+_tl;dr: I joined the [Sovereign Tech Agency](https://www.sovereign.tech/) as a Technologist to help make OSS more sustainable. It's a dream role that combines my passion for open source with my desire to tackle its biggest challenges._
 
 Oh, hi there! It's been a while, hasn't it? It's been over a month since I announced [the closing of the React Native chapter](https://kelset.dev/blog/closing-the-react-native-chapter/) of my career - and I just want to call out one more time that the support and love and energy I've received was beyond my wildest expectations. So thank you for it, and thank you sticking around even after that ☺️
 
@@ -20,7 +20,7 @@ Today, I'm thrilled to finally reveal what I've been cooking up: as you've read 
 
 The Sovereign Tech Agency is one of the few organizations in the WORLD that bring the public sector (you know, the government/state) into the Open Source sustainability conversation. In particular, they do so as a Germany-state entity. In other words: they obtain money from the German government and, through a couple of different programs, give them to Open Source maintainers to help them be sustainable and have more solid foundations.
 
-The [mission statement](https://www.sovereign.tech//mission) says it better:
+The [mission statement](https://www.sovereign.tech/mission) says it better:
 
 > The Sovereign Tech Agency supports the development, improvement, and maintenance of open digital infrastructure. Our goal is to sustainably strengthen the open source ecosystem. We focus on security, resilience, technological diversity, and the people behind the code.
 
@@ -35,7 +35,7 @@ STF isn't just trying to give some money to some OSS projects to have them do wh
 
 And this, this is so DAMN AWESOME.
 
-I’ve been the person doing the boring, janitorial work in SO MANY occasions and I know oh-so-well how hard it is to find the motivation and discipline to tackle them; and when you are overburdened, working under a lot of pressure, those are usually the first things to get pushed down at the bottom of the backlog, despite their (sometimes critical) importance. I truly think that this project, with this focus, can truly be a game changer for sustainability. _(…did I mention there’s also a [Bug Resilience Program](https://www.sovereign.tech//programs/bug-resilience)?)_
+I’ve been the person doing the boring, janitorial work in SO MANY occasions and I know oh-so-well how hard it is to find the motivation and discipline to tackle them; and when you are overburdened, working under a lot of pressure, those are usually the first things to get pushed down at the bottom of the backlog, despite their (sometimes critical) importance. I truly think that this project, with this focus, can truly be a game changer for sustainability. _(…did I mention there’s also a [Bug Resilience Program](https://www.sovereign.tech/programs/bug-resilience)?)_
 
 Moreover, because it’s one of the few in the world of this kind, there’s also the angle of leading by example, which makes it all even more exciting.
 
@@ -43,9 +43,9 @@ Moreover, because it’s one of the few in the world of this kind, there’s als
 
 To give you an idea of the scale we're talking about, here are a few examples of projects supported by STF:
 
-- [GNOME: €1,000,000.00](https://www.sovereign.tech//tech/gnome) (yes, 1 FLIPPIN’ MILLION)
-- [PHP: €205,000.00](https://www.sovereign.tech//tech/php)
-- [OpenJS Foundation (you know, NodeJS, JQuery, etc): €874,940.00](https://www.sovereign.tech//tech/openjs)
+- [GNOME: €1,000,000.00](https://www.sovereign.tech/tech/gnome) (yes, 1 FLIPPIN’ MILLION)
+- [PHP: €205,000.00](https://www.sovereign.tech/tech/php)
+- [OpenJS Foundation (you know, NodeJS, JQuery, etc): €874,940.00](https://www.sovereign.tech/tech/openjs)
 
 And these are only a few of the 40 technologies supported since October 2022. The magnitude is truly impressive, isn't it? _(yeah I mean I guess it’s probably pretty clear why I joined them already)_
 
@@ -65,9 +65,9 @@ My role at STF is essentially being the person in the room with technical expert
 2. Communicate and collaborate externally with maintainers and other partners and companies.
 3. _(…and probably a bunch more things - again I’m still figuring it out ok!?_ 🤣*)*
 
-Especially in the context of [our main investing program](https://www.sovereign.tech//programs/applications), which is a quite an involved process, this is super relevant: as I mentioned before, it’s not just “here’s a bunch of money, go wild”, but much more about working together with the maintainers in coming up with a series of important tasks they want to tackle and figuring out how much money they need to sustain those, and then checking in along the way.
+Especially in the context of [our main investing program](https://www.sovereign.tech/programs/applications), which is a quite an involved process, this is super relevant: as I mentioned before, it’s not just “here’s a bunch of money, go wild”, but much more about working together with the maintainers in coming up with a series of important tasks they want to tackle and figuring out how much money they need to sustain those, and then checking in along the way.
 
-For some examples of what I mean, read out the “What are we funding?” section of any of the technologies funded so far (like, here’s [Log4j](https://www.sovereign.tech//tech/log4j)).
+For some examples of what I mean, read out the “What are we funding?” section of any of the technologies funded so far (like, here’s [Log4j](https://www.sovereign.tech/tech/log4j)).
 
 ### _How React Native prepared me_
 


### PR DESCRIPTION
## Summary
- clean up Sovereign Tech links with duplicate slashes

## Testing
- `grep -n "https://www.sovereign.tech//" content/blog/focusing-on-open-source/index.md`


------
https://chatgpt.com/codex/tasks/task_e_684014c489a0832fbba09b6f789c899e